### PR TITLE
Fix infinite loops with small terminals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,13 @@ set(CMAKE_CXX_STANDARD 17)
 option(BUILD_EXE OFF)
 option(BUILD_BINDINGS ON)
 option(LINK_STATIC OFF)
+option(USE_CONDA_PYTHON ON)
+
+if (USE_CONDA_PYTHON)
+    message("Using conda prefix: $ENV{CONDA_PREFIX}")
+    set(PYTHON_EXECUTABLE "$ENV{CONDA_PREFIX}/bin/python")
+    set(PYTHON_LIBRARIES "$ENV{CONDA_PREFIX}/lib/")
+endif ()
 
 find_package(Threads REQUIRED)
 find_library(LIBSOLV_LIBRARIES NAMES solv)

--- a/include/output.hpp
+++ b/include/output.hpp
@@ -59,7 +59,7 @@ namespace cursor
 
     inline auto up(int n)
     {
-        return CursorMovementTriple("up[", n, "A");
+        return CursorMovementTriple("\x1b[", n, "A");
     }
 
     inline auto down(int n)
@@ -198,8 +198,6 @@ namespace mamba
         std::string m_lead;
         std::string m_remainder;
     };
-
-    int get_console_width();
 
     class ProgressBar
     {

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -74,8 +74,8 @@ namespace mamba
 
     std::ostream& ProgressScaleWriter::write(std::ostream& os, std::size_t progress) const
     {
-        auto pos = static_cast<size_t>(progress * m_bar_width / 100.0);
-        for (size_t i = 0; i < static_cast<size_t>(m_bar_width); ++i)
+        int pos = int(progress * m_bar_width / 100.0);
+        for (int i = 0; i < m_bar_width; ++i)
         {
             if (i < pos)
             {
@@ -172,8 +172,8 @@ namespace mamba
         }
         else
         {
-            auto pos = static_cast<std::size_t>(m_progress * width / 100.0);
-            for (size_t i = 0; i < static_cast<size_t>(width); ++i)
+            auto pos = int(m_progress * width / 100.0);
+            for (int i = 0; i < width; ++i)
             {
                 if (i == pos - 1)
                 {
@@ -428,7 +428,7 @@ namespace mamba
                 {
                     const std::lock_guard<std::mutex> lock(instance().m_mutex);
                     const auto& ps = instance().m_active_progress_bars.size();
-                    std::cout << cursor::prev_line(ps) << cursor::erase_line()
+                    std::cout << cursor::up(ps) << cursor::erase_line()
                               << str << std::endl;
 
                     if (!Console::instance().skip_progress_bars())
@@ -522,7 +522,7 @@ namespace mamba
 
         m_active_progress_bars.erase(it);
         int ps = m_active_progress_bars.size();
-        std::cout << cursor::prev_line(ps + 1) << cursor::erase_line();
+        std::cout << cursor::up(ps + 1) << cursor::erase_line();
         if (msg.empty())
         {
             m_progress_bars[idx]->print();
@@ -547,7 +547,7 @@ namespace mamba
         std::size_t cursor_up = m_active_progress_bars.size();
         if (m_progress_started && cursor_up > 0)
         {
-            std::cout << cursor::prev_line(cursor_up);
+            std::cout << cursor::up(cursor_up);
         }
 
         auto it = std::find(m_active_progress_bars.begin(), m_active_progress_bars.end(), m_progress_bars[idx].get());

--- a/src/transaction_context.cpp
+++ b/src/transaction_context.cpp
@@ -61,8 +61,8 @@ namespace mamba
     }
 
     TransactionContext::TransactionContext(const fs::path& prefix, const std::string& py_version)
-        : has_python(python_version.size() != 0)
-	, target_prefix(prefix)
+        : has_python(py_version.size() != 0)
+        , target_prefix(prefix)
         , python_version(py_version)
     {
         if (python_version.size() == 0)


### PR DESCRIPTION
There were some casts to size_t that resulted in some infinite loops in combination with negative numbers.

Fixes #337 