### PR TITLE
link libstdc++ and libgcc statically as well

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,8 @@ if (LINK_STATIC)
     elseif (UNIX)
         set(MAMBA_FORCE_DYNAMIC_LIBS rt dl c resolv)
     endif()
+
+    add_link_options(-static-libstdc++ -static-libgcc)
 endif()
 
 if (LINK_STATIC)


### PR DESCRIPTION
Looks like this works really well (even worked on centos 6).
