### PR TITLE
Fix issue #389: mamba run throws away exit code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ installed.json
 *.so
 __pycache__
 .vscode
+.idea
 .ipynb_checkpoints
 build/
 tmp/

--- a/mamba/mamba.py
+++ b/mamba/mamba.py
@@ -766,7 +766,8 @@ def _wrapped_main(*args, **kwargs):
 
     init_loggers(context)
 
-    exit_code = do_call(args, p)
+    result = do_call(args, p)
+    exit_code = getattr(result, 'rc', result) # may be Result objects with code in rc field
     if isinstance(exit_code, int):
         return exit_code
 


### PR DESCRIPTION
Did not see an easy way to add a test for this, but tested it manually.
