### PR TITLE
Improved pinning

### DIFF
--- a/include/solver.hpp
+++ b/include/solver.hpp
@@ -45,6 +45,7 @@ namespace mamba
 
         void add_jobs(const std::vector<std::string>& jobs, int job_flag);
         void add_constraint(const std::string& job);
+        void add_pin(const std::string& job);
         void set_flags(const std::vector<std::pair<int, int>>& flags);
         void set_postsolve_flags(const std::vector<std::pair<int, int>>& flags);
         bool is_solved();

--- a/mamba/mamba.py
+++ b/mamba/mamba.py
@@ -401,27 +401,15 @@ def install(args, parser, command='install'):
     # for 'conda update', make sure the requested specs actually exist in the prefix
     # and that they are name-only specs
     if isupdate and context.update_modifier == UpdateModifier.UPDATE_ALL:
-        history_dict = History(prefix).get_requested_specs_map()
-        pins = {
-            pin.name: pin
-            for pin in get_pinned_specs(prefix)
-        }
-        # for key, match_spec in history_dict.items():
-        for key in installed_names:
-            if key == 'python':
-                i = installed_names.index('python')
-                version = installed_pkg_recs[i].version
-                py_ver = ".".join(version.split(".")[:2]) + '.*'
-                # specs.append(MatchSpec(name="python", version=py_ver))
-            else:
-                if key in pins:
-                    specs.append(pins[key])
-                else:
-                    specs.append(MatchSpec(key))
+        for i in installed_names:
+            if i != 'python':
+                specs.append(MatchSpec(i))
 
         prefix_data = PrefixData(prefix)
         for s in args_packages:
             s = MatchSpec(s)
+            if s.name == 'python':
+                specs.append(s)
             if not s.is_name_only_spec:
                 raise CondaValueError("Invalid spec for 'conda update': %s\n"
                                       "Use 'conda install' instead." % s)
@@ -510,7 +498,21 @@ def install(args, parser, command='install'):
                 solver.add_jobs([a_pkg], api.SOLVER_UPDATE)
 
     if python_constraint:
-        solver.add_constraint(python_constraint)
+        solver.add_pin(python_constraint)
+
+    pinned_specs = get_pinned_specs(context.target_prefix)
+    if pinned_specs:
+        conda_prefix_data = PrefixData(context.target_prefix)
+    for s in pinned_specs:
+        x = conda_prefix_data.query(s.name)
+        if x:
+            for el in x:
+                if not s.match(el):
+                    print("Your pinning does not match what's currently installed. Please remove the pin and fix your installation")
+                    print("  Pin: {}".format(s))
+                    print("  Currently installed: {}".format(el))
+                    exit(1)
+        solver.add_pin(str(s))
 
     success = solver.solve()
     if not success:

--- a/mamba/mamba.py
+++ b/mamba/mamba.py
@@ -503,10 +503,11 @@ def install(args, parser, command='install'):
     )
     solver.add_jobs(mamba_solve_specs, solver_task)
 
-    # as a security feature this will _always_ attempt to upgrade certain packages
-    for a_pkg in [_.name for _ in context.aggressive_update_packages]:
-        if a_pkg in installed_names:
-            solver.add_jobs([a_pkg], api.SOLVER_UPDATE)
+    if not context.force_reinstall:
+        # as a security feature this will _always_ attempt to upgrade certain packages
+        for a_pkg in [_.name for _ in context.aggressive_update_packages]:
+            if a_pkg in installed_names:
+                solver.add_jobs([a_pkg], api.SOLVER_UPDATE)
 
     if python_constraint:
         solver.add_constraint(python_constraint)

--- a/src/py_interface.cpp
+++ b/src/py_interface.cpp
@@ -73,6 +73,7 @@ PYBIND11_MODULE(mamba_api, m) {
         .def(py::init<MPool&, std::vector<std::pair<int, int>>, const PrefixData*>())
         .def("add_jobs", &MSolver::add_jobs)
         .def("add_constraint", &MSolver::add_constraint)
+        .def("add_pin", &MSolver::add_pin)
         .def("set_flags", &MSolver::set_flags)
         .def("set_postsolve_flags", &MSolver::set_postsolve_flags)
         .def("is_solved", &MSolver::is_solved)

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -8,6 +8,7 @@
 #include "output.hpp"
 #include "util.hpp"
 #include "package_info.hpp"
+#include "channel.hpp"
 
 namespace mamba
 {
@@ -46,7 +47,8 @@ namespace mamba
             // TODO this might match too much (e.g. bioconda would also match bioconda-experimental etc)
             // Note: s->repo->name is the URL of the repo
             // TODO maybe better to check all repos, select pointers, and compare the pointer (s->repo == ptr?)
-            if (std::string_view(s->repo->name).find(ms.channel) != std::string_view::npos)
+            Channel& chan = make_channel(s->repo->name);
+            if (chan.url(false).find(ms.channel) != std::string::npos)
             {
                 queue_push(&selected_pkgs, *wp);
             }


### PR DESCRIPTION
This will allow us to properly pin packages (with optional channel argument).

Fixes #171 
Fixes #328 

I hope that this will also be helpful in `boa` where we can use this mechanism to even pin down transitive dependencies, something that (afaik) `conda-build` doesn't currently do.

cc @dhirschfeld 