### PR TITLE
Does not update python when updating enrivonment

### DIFF
--- a/include/thread_utils.hpp
+++ b/include/thread_utils.hpp
@@ -18,9 +18,6 @@
 namespace mamba
 {
 
-#ifdef MAMBA_TEST_SUITE
-#endif
-
     /***********************
      * thread interruption *
      ***********************/

--- a/mamba/mamba_env.py
+++ b/mamba/mamba_env.py
@@ -75,8 +75,15 @@ def mamba_install(prefix, specs, args, env, *_, **kwargs):
         repo.set_priority(priority, subpriority)
         repos.append(repo)
 
+    
     solver = api.Solver(pool, solver_options)
     solver.add_jobs(specs, api.SOLVER_INSTALL)
+
+    python_version = [irec.version for irec in installed_pkg_recs if irec.name == 'python']
+    if python_version:
+        python_constraint = MatchSpec('python==' + version).conda_build_form()
+        solver.add_pin(python_constraint)
+
     success = solver.solve()
     if not success:
         print(solver.problems_to_str())


### PR DESCRIPTION
This should allow binder to test/use mamba.

cc @SylvainCorlay @wolfv 