### PR TITLE
fix on http 1.1 so that we have more time to iron out http 2 behavior

### DIFF
--- a/src/fetch.cpp
+++ b/src/fetch.cpp
@@ -54,6 +54,12 @@ namespace mamba
         // DO NOT SET TIMEOUT as it will also take into account multi-start time and it's just wrong
         // curl_easy_setopt(m_handle, CURLOPT_TIMEOUT, Context::instance().read_timeout_secs);
 
+        // TODO while libcurl in conda now _has_ http2 support we need to fix mamba to work properly with it
+        // this includes:
+        // - setting the cache stuff correctly
+        // - fixing how the progress bar works
+        curl_easy_setopt(m_handle, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
+
         // if the request is slower than 30b/s for 60 seconds, cancel.
         curl_easy_setopt(m_handle, CURLOPT_LOW_SPEED_TIME, 60L);
         curl_easy_setopt(m_handle, CURLOPT_LOW_SPEED_LIMIT, 30L);


### PR DESCRIPTION
We have some issues with http2 in curl right now:

- the repodata cache doesn't seem to be properly working
- the progress bars are messed up because it attempts to download all packages at once

We'll have to fix that soon!