### PR TITLE
Fix oversized banner

### DIFF
--- a/mamba/mamba.py
+++ b/mamba/mamba.py
@@ -81,7 +81,7 @@ banner = f"""
 
         mamba ({mamba.__version__}) supported by @QuantStack
 
-        GitHub:  https://github.com/QuantStack/mamba
+        GitHub:  https://github.com/TheSnakePit/mamba
         Twitter: https://twitter.com/QuantStack
 
 █████████████████████████████████████████████████████████████

--- a/mamba/mamba.py
+++ b/mamba/mamba.py
@@ -871,6 +871,13 @@ def _wrapped_main(*args, **kwargs):
         use_mamba_experimental = True
         argv.remove("--mamba-experimental")
 
+    print_banner = True
+    if "--no-banner" in argv:
+        print_banner = False
+        argv.remove("--no-banner")
+    elif "MAMBA_NO_BANNER" in os.environ:
+        print_banner = False
+
     args = argv
 
     p = generate_parser()
@@ -878,7 +885,7 @@ def _wrapped_main(*args, **kwargs):
     args = p.parse_args(args[1:])
 
     context.__init__(argparse_args=args)
-    if not (context.quiet or context.json):
+    if print_banner and not (context.quiet or context.json):
         print(banner)
 
     init_loggers(context)


### PR DESCRIPTION
Fixes #66 

This add an argument `--no-banner` and an environment variable `MAMBA_NO_BANNER` to hide the mamba banner

> I also updated the github repository url in the banner