### PR TITLE
Use ~/.netrc if present

### DIFF
--- a/src/fetch.cpp
+++ b/src/fetch.cpp
@@ -35,6 +35,7 @@ namespace mamba
     void DownloadTarget::init_curl_target(const std::string& url)
     {
         curl_easy_setopt(m_handle, CURLOPT_URL, url.c_str());
+        curl_easy_setopt(m_handle, CURLOPT_NETRC, CURL_NETRC_OPTIONAL);
 
         curl_easy_setopt(m_handle, CURLOPT_HEADERFUNCTION, &DownloadTarget::header_callback);
         curl_easy_setopt(m_handle, CURLOPT_HEADERDATA, this);


### PR DESCRIPTION
When private packages are hosted in a private package repository, the repository can be behind access cotrol methods. This PR adds the simplest form with .netrc file. By the way, conda also supports .netrc too.